### PR TITLE
encourage parallelism in rl_exercise02.ipynb solutions

### DIFF
--- a/rl_exercises/rl_exercise02.ipynb
+++ b/rl_exercises/rl_exercise02.ipynb
@@ -52,7 +52,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "ray.init()"
@@ -68,7 +70,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "class TwoLayerPolicy(object):\n",
@@ -105,7 +109,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# NOTE: You may find the helper function 'rollout_policy' helpful.\n",
@@ -128,18 +134,20 @@
     "    return cumulative_reward\n",
     "\n",
     "@ray.remote\n",
+    "def rollout_cartpole_once(policy):\n",
+    "    # Create an environment.\n",
+    "    env = gym.make('CartPole-v0')\n",
+    "    return rollout_policy(env, policy)    \n",
+    "\n",
     "def evaluate_random_policy(num_rollouts):\n",
     "    # Generate a random policy.\n",
     "    policy = TwoLayerPolicy(4, 5)\n",
     "    \n",
-    "    # Create an environment.\n",
-    "    env = gym.make('CartPole-v0')\n",
-    "    \n",
     "    # EXERCISE: Do 'num_rollouts' rollouts using the policy and the\n",
-    "    # environment, and return the average reward obtained by the rollouts.\n",
+    "    # environment, and return the average reward obtained by the rollouts. \n",
     "    raise NotImplementedError\n",
-    "    \n",
-    "average_reward = ray.get(evaluate_random_policy.remote(10))\n",
+    "\n",
+    "average_reward = evaluate_random_policy(10)\n",
     "print(average_reward)"
    ]
   },


### PR DESCRIPTION
A typical mistake during Risecamp was induced by the format of the exercise in the rl_exercise02.ipynb notebook.

Before:
	@ray.remote
	def evaluate_random_policy(parallelism):
		policy = ...
		env = ...
		# <people implement here>
		# huh? remote is supposed to run the policy `parallelism` times? What does ray do here?
		# people tried to make new remote calls here
		# that required serializing gym, which is problematic for both random-seed and pickling reasons

After:
	@ray.remote
	def evaluate_cartpole_once(policy):
		env = ...
		return ...

	def evaluate_random_policy():
		policy = ...

		# <people implement here>
		# writing code here should lead to naturally-parallelizing solutions
