### PR TITLE
fix typo rl_exercise02.ipynb

### DIFF
--- a/rl_exercises/rl_exercise02.ipynb
+++ b/rl_exercises/rl_exercise02.ipynb
@@ -82,7 +82,7 @@
     "    def __call__(self, state):\n",
     "        hiddens = np.maximum(np.dot(self.weights1, state) + self.biases1, 0)\n",
     "        output = np.dot(self.weights2, hiddens) + self.biases2\n",
-    "        assert output.size == 1\n",
+    "        assert output.size == self.num_outputs\n",
     "        return 0 if output[0] < 0 else 1\n",
     "\n",
     "policy = TwoLayerPolicy(4, 5)\n",


### PR DESCRIPTION
The assert should be equal to `num_outputs` since it's configurable from init.