### PR TITLE
Added Binder Link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,15 @@
 Ray Tutorial
 ============
 
-Setup
------
+Try Ray on Binder (Experimental)
+--------------------------------
+
+Try the Ray tutorials online on `Binder`_.
+
+.. _`Binder`: https://mybinder.org/v2/gh/ray-project/tutorial/master
+
+Local Setup
+-----------
 
 1. Make sure you have Python installed (we recommend using the `Anaconda Python
    distribution`_). Ray works with both Python 2 and Python 3. If you are unsure

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: ray-tutorial
+channels:
+    - conda-forge
+dependencies:
+  - python=3.6
+  - bokeh
+  - ipywidgets=6.0.0
+  - tensorflow
+  - opencv
+  - pip:
+    - ray
+    - gym


### PR DESCRIPTION
@robertnishihara Closes #54 .


To see the binder:

https://mybinder.org/v2/gh/jzf2101/tutorial/master

To get this to work I've created an `environment.yml` file and changed the `README.rst` as appropriate.  

The binder link points to my fork. As a follow-up, it would be better to replace the link with a binder to this repo.  Also, JupyterLab experience would be improved if the readme was converted to `.md` since it has a native `.md` reader that can be used during the tutorial.  This could be used also for Binder.