### PR TITLE
Update module name for a3c import

### DIFF
--- a/rl_exercises/rl_exercise04.ipynb
+++ b/rl_exercises/rl_exercise04.ipynb
@@ -27,8 +27,8 @@
     "\n",
     "import gym\n",
     "import ray\n",
-    "from ray.rllib.a3c import A3CAgent, DEFAULT_CONFIG\n",
-    "from ray.rllib.a3c.shared_model import SharedModel"
+    "from ray.rllib.agents.a3c import A3CAgent, DEFAULT_CONFIG\n",
+    "#from ray.rllib.a3c.shared_model import SharedModel"
    ]
   },
   {


### PR DESCRIPTION
And masking the import of ray.rllib.a3c.shared_model. Is it still used? if yes, what's the correct import?