### PR TITLE
setting redis version to 2.10.6 for Ray 0.5.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,3 +11,4 @@ dependencies:
     - keras
     - modin
     - matplotlib
+    - redis==2.10.6


### PR DESCRIPTION
Ray 0.5.3 did does not work with most recent version of redis, so fixing redis version to 2.10.6 as a temporary fix