### PR TITLE
Fix exercises so that they work on binder

### DIFF
--- a/exercises/exercise03-Nested_Remote_Functions.ipynb
+++ b/exercises/exercise03-Nested_Remote_Functions.ipynb
@@ -146,7 +146,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**VERIFY:** Run some checks to verify that the changes you made to the code were correct. Some of the checks should fail when you initially run the cells. After completing the exercises, the checks should pass."
+    "**VERIFY:** Run some checks to verify that the changes you made to the code were correct. Some of the checks should fail when you initially run the cells. After completing the exercises, the checks should pass.\n",
+    "\n",
+    "**NOTE:** This exercise is known to have issues on binder that can be resolved by rerunning the above cell a second time."
    ]
   },
   {

--- a/exercises/exercise08-Serialization.ipynb
+++ b/exercises/exercise08-Serialization.ipynb
@@ -90,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "neural_net_weights = {'variable{}'.format(i): np.random.normal(size=1000000)\n",
+    "neural_net_weights = {'variable{}'.format(i): np.random.normal(size=2**18)\n",
     "                      for i in range(50)}"
    ]
   },


### PR DESCRIPTION
This commit changes exercises 3 and 8 so that

- in exercise 3, there is a note for the user that tells them to simply rerun the cell to pass the test
- in exercise 8, reduce the size from 1,000,000 to 2**18 so that it runs on binder