### PR TITLE
Reset top accuracy if we have a new top accuracy

### DIFF
--- a/tune_exercises/helper.py
+++ b/tune_exercises/helper.py
@@ -68,6 +68,7 @@ class TuneCallback(keras.callbacks.Callback):
         if curr_acc > self.top_acc:
             self.model.save_weights("weights_tune_tmp.h5")
             os.rename("weights_tune_tmp.h5", "weights_tune.h5")
+            self.top_acc = curr_acc
 
         if len(self.last_10_results) >= 5:
             self.last_10_results = self.last_10_results[1:]

--- a/tune_exercises/helper.py
+++ b/tune_exercises/helper.py
@@ -66,9 +66,9 @@ class TuneCallback(keras.callbacks.Callback):
         """Reports the last result"""
         curr_acc = logs["acc"]
         if curr_acc > self.top_acc:
+            self.top_acc = curr_acc
             self.model.save_weights("weights_tune_tmp.h5")
             os.rename("weights_tune_tmp.h5", "weights_tune.h5")
-            self.top_acc = curr_acc
 
         if len(self.last_10_results) >= 5:
             self.last_10_results = self.last_10_results[1:]


### PR DESCRIPTION
Currently, the top accuracy is always -1 and is never updated. This PR adds a line to update the top accuracy.