### PR TITLE
Install requests library in exercise02-Task_Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .ipynb_checkpoints
 *.h5
+.DS_Store

--- a/exercises/exercise02-Task_Dependencies.ipynb
+++ b/exercises/exercise02-Task_Dependencies.ipynb
@@ -229,6 +229,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip install requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from bs4 import BeautifulSoup\n",
     "import requests\n",
     "\n",


### PR DESCRIPTION
The requests library is not installed as part of the conda environment

Testing Done: run the notebook

Revert Plan: git revert