### PR TITLE
[MINOR] Update jupyter command reference to match

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ opened in Jupyter lab by running the following commands.
   cd tutorial/exercises
   jupyter-lab
 
-If it asks for a password, just hit enter.
+If you don't have `jupyter-lab`, try `jupyter-notebook`. If it asks for a password, just hit enter.
 
 Instructions are written in each file. To do each exercise, first run all of
 the cells in Jupyter lab. Then modify the ones that need to be modified

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Try Tune on Google Colab
 
 Tuning hyperparameters is often the most expensive part of the machine learning workflow. `Ray Tune <http://tune.io>`_ is built to address this, demonstrating an efficient and scalable solution for this pain point.
 
-`Exercise 1 <https://github.com/ray-project/tutorial/tree/master/tune_exercises/exercise_1_basics.ipynb>`_ covers basics of using Tune - creating your first training function and using Tune. This tutorial uses Keras. 
+`Exercise 1 <https://github.com/ray-project/tutorial/tree/master/tune_exercises/exercise_1_basics.ipynb>`_ covers basics of using Tune - creating your first training function and using Tune. This tutorial uses Keras.
 
 .. raw:: html
 
@@ -44,7 +44,7 @@ Tuning hyperparameters is often the most expensive part of the machine learning 
     <a href="https://colab.research.google.com/github/ray-project/tutorial/blob/master/tune_exercises/exercise_3_pbt.ipynb" target="_parent">
     <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Tune Tutorial"/>
     </a>
-    
+
 Try Ray on Binder
 -----------------
 
@@ -73,7 +73,7 @@ Local Setup
 
 
 2. **Install Jupyter** with ``pip install jupyter``. Verify that you can start
-   Jupyter lab with the command ``jupyter-lab``.
+   Jupyter lab with the command ``jupyter-lab`` or ``jupyter-notebook``.
 
 3. **Install Ray** by running ``pip install -U ray``. Verify that you can run
 


### PR DESCRIPTION
I was doing a quick run-through of some of the tutorials, noticed that this references `jupyter-lab` as the launch command but for me with Python 3.6 and a new virtual environment I got `jupyter-notebook`. You can see the stream at https://www.youtube.com/watch?v=WBNmF-wyAlE
Thanks for making the tutorials y'all :)

There are also some small whitespaces cleanup changes that my emacs configuration did automatically, I can back them out if folks prefer.