### PR TITLE
Tune exercise 3#: Fix small typo resulting in import error

### DIFF
--- a/tune_exercises/exercise_3_pbt.ipynb
+++ b/tune_exercises/exercise_3_pbt.ipynb
@@ -68,7 +68,7 @@
     "from ray import tune\n",
     "from ray.tune import track\n",
     "from ray.tune.schedulers import PopulationBasedTraining\n",
-    "from ray.tune.util import validate_save_restore\n",
+    "from ray.tune.utils import validate_save_restore\n",
     "\n",
     "%matplotlib inline\n",
     "import matplotlib.style as style\n",


### PR DESCRIPTION
Changed
```
from ray.tune.util import validate_save_restore
```
to
```
from ray.tune.utils import validate_save_restore
```
avoiding an import error.